### PR TITLE
Allow multiple statements

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ exports.init = async (cfg) => {
   config = cfg;
 };
 
-exports.createPool = async (poolName, allowMultiStatements) => {
+exports.createPool = async (poolName, allowMultiStatements = false) => {
   try {
     const srcCfg = config.DATASOURCES[poolName];
     if (srcCfg) {
@@ -22,7 +22,7 @@ exports.createPool = async (poolName, allowMultiStatements) => {
         password: srcCfg.DB_PASSWORD,
         database: srcCfg.DB_DATABASE,
         port: srcCfg.PORT,
-        multipleStatements: allowMultiStatements || false,
+        multipleStatements: allowMultiStatements,
       });
       console.debug(`MySQL Adapter: Pool ${poolName} created`);
       return true;

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ exports.init = async (cfg) => {
   config = cfg;
 };
 
-exports.createPool = async (poolName) => {
+exports.createPool = async (poolName, allowMultiStatements) => {
   try {
     const srcCfg = config.DATASOURCES[poolName];
     if (srcCfg) {
@@ -22,6 +22,7 @@ exports.createPool = async (poolName) => {
         password: srcCfg.DB_PASSWORD,
         database: srcCfg.DB_DATABASE,
         port: srcCfg.PORT,
+        multipleStatements: allowMultiStatements || false,
       });
       console.debug(`MySQL Adapter: Pool ${poolName} created`);
       return true;
@@ -35,10 +36,10 @@ exports.createPool = async (poolName) => {
   }
 };
 
-exports.connect = async (poolName) => {
+exports.connect = async (poolName, allowMultiStatements) => {
   try {
     if (!pools[poolName]) {
-      await this.createPool(poolName);
+      await this.createPool(poolName, allowMultiStatements);
     }
     return pools[poolName];
   } catch (err) {


### PR DESCRIPTION
1. Add am optional `allowMultiStatements` param to the `connect` method, default to `False`. (This means it will not break all existing projects that are using this package.)
2. If `true` is passed in, it will enable executing queries with multiple statements by separating each statement with a semi-colon ; . Result will be an array for each statement. All statements will be executed in one transaction. 
