### PR TITLE
Bug fix: closing pools

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 12
-      - run: npm ci
+      - run: yarn
 #       - run: npm test
 
   publish-npm:
@@ -30,7 +30,7 @@ jobs:
         with:
           node-version: 12
           registry-url: https://registry.npmjs.org/
-      - run: npm ci
-      - run: npm publish
+      - run: yarn
+      - run: yarn publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ combined.log
 database.log
 perf.log
 http.log
+
+# IDE
+.idea

--- a/index.js
+++ b/index.js
@@ -97,10 +97,9 @@ exports.execute = async (srcName, query, params = {}) => {
 
 exports.closeAllPools = async () => {
   try {
-    const tempPools = pools;
-    pools = {};
-    for (const poolAlias of Object.keys(tempPools)) {
+    for (const poolAlias of Object.keys(pools)) {
       await this.closePool(poolAlias);
+      delete pools[poolAlias];
       console.debug(`MySQL Adapter: Pool ${poolAlias} closed`);
     }
     return true;
@@ -115,7 +114,7 @@ exports.closePool = async (poolAlias) => {
     if (pools[poolAlias]) {
       const poolConn = pools[poolAlias];
       delete pools[poolAlias];
-      poolConn.end((err) => {
+      await poolConn.end((err) => {
         if (err) {
           console.error(
             `Error while closing connection pool ${poolAlias}`,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@softrams/nodejs-mysql-connector",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Database connector wrapper to work with MySQL database from nodejs applications",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The logic for closing pools is currently incorrect and results in no pools being closed when you call `closeAllPools`.

The current code:

```
    const tempPools = pools;
    pools = {};
    for (const poolAlias of Object.keys(tempPools)) {
      await this.closePool(poolAlias);
      console.debug(`MySQL Adapter: Pool ${poolAlias} closed`);
    }
```

Because we set `pools` to be an empty object `{}`, when `this.closePool` is called, the method will be checking to see if a key is on the `pools` object. However, since it was just set to be an empty object, this will never be true.

```
exports.closePool = async (poolAlias) => { 
  try {
    if (pools[poolAlias]) { // pools = {}, this will always be false
```

Because we use lambda's, I don't think anyone has ever attempted using this connector as part of integration tests, and found the leaked connection. 4Real in 4i is implementing integration tests and ran into this issue.


