### PR TITLE
Allow passing timezone as config

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ exports.createPool = async (poolName) => {
         database: srcCfg.DB_DATABASE,
         port: srcCfg.PORT,
         multipleStatements: srcCfg.ALLOW_MULTI_STATEMENTS || false,
+        timezone: srcCfg.TIMEZONE || 'local',
       });
       console.debug(`MySQL Adapter: Pool ${poolName} created`);
       return true;


### PR DESCRIPTION
MySql node adapter automatically parses `datetime` query fields as a new JavaScript `Date` object. By default, the timezone used is `local`, which for AWS Lambda is UTC. Some projects, such as 4i, have their mysql database running in Eastern time, so fields retrieved and queried are returned in the wrong timezone.

This new parameter allows passing a timezone offset to the mysql connector when a pool is established, or defaults to `local` which is the default. 

For reference: 
https://github.com/mysqljs/mysql#connection-options