### PR TITLE
Add option to return generic messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Wrapper utility to easily manage multiple data sources and pooled connections.
 
+## Error Returns
+
+By default, all errors occurring during a query are returned. If you want to be extra-safe in a production environment, you can set `HIDE_DB_ERRORS` value on the root `config` passed to the connector on initialization. When you do this, all errors will be logged, but none returned when a query error occurs. 
+
 ## SSL Settings
 
 This connector allows setting SSL connection using a few different options.

--- a/index.js
+++ b/index.js
@@ -70,6 +70,7 @@ this.query = async (conn, query, params) => {
     try {
       conn.query(query, params, (error, results) => {
         if (error) {
+          console.error("MySQL Adapter:  Failure in query: ", error);    
           this.handleError(reject, error);
         } else {
           resolve(results);

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const fs = require('fs');
 
 let pools = {};
 let config = {};
+const genericError = 'An error occurred communicating with the database.';
 
 exports.init = async (cfg) => {
   config = cfg;
@@ -69,16 +70,21 @@ this.query = async (conn, query, params) => {
     try {
       conn.query(query, params, (error, results) => {
         if (error) {
-          reject(error);
+          this.handleError(reject, error);
         } else {
           resolve(results);
         }
       });
     } catch (err) {
       console.error("MySQL Adapter:  Failure in query: ", err);
-      reject(err);
+      this.handleError(reject, err);
     }
   });
+};
+
+this.handleError = (reject, error) => {
+  const errorReturn = (config && config.HIDE_DB_ERRORS) ? new Error(genericError) : error;
+  reject(errorReturn);
 };
 
 exports.execute = async (srcName, query, params = {}) => {


### PR DESCRIPTION
To make usage of this adapter extra safe in production environments, this would allow consumers of this package to log, but not return query related errors. 