### PR TITLE
add ability to not auto cast returns to their javascript type, and al…

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Wrapper utility to easily manage multiple data sources and pooled connections.
 
 ## Error Returns
 
-By default, all errors occurring during a query are returned. If you want to be extra-safe in a production environment, you can set `HIDE_DB_ERRORS` value on the root `config` passed to the connector on initialization. When you do this, all errors will be logged, but none returned when a query error occurs. 
+By default, all errors occurring during a query are returned. If you want to be extra-safe in a production environment, you can set `HIDE_DB_ERRORS` value on the root `config` passed to the connector on initialization. When you do this, all errors will be logged, but none returned when a query error occurs.
 
 ## SSL Settings
 
@@ -25,3 +25,9 @@ SSL: {
   REJECT_UNAUTHORIZED: false // not recommended
 }
 ```
+
+#Data Typing Options
+
+This connector gives you a few options for configuring how data is returned from the connector. 'typeCast' defaults to true, and converts
+data from the database to its javascript equivalent. For example, it will convert DATETIME SQL objects to a DATE javascript type.
+You can also set 'dateStrings' which defaults to false. If you set it to true it will override typeCast and force date returns to be a string instead of a DATE type.

--- a/index.js
+++ b/index.js
@@ -26,6 +26,8 @@ exports.createPool = async (poolName) => {
         port: srcCfg.PORT,
         multipleStatements: srcCfg.ALLOW_MULTI_STATEMENTS || false,
         timezone: srcCfg.TIMEZONE || 'local',
+        typeCast: srcCfg.TYPE_CAST || true,
+        dateStrings: srcCfg.DATE_STRINGS || false
       };
 
       if (srcCfg.SSL) {


### PR DESCRIPTION
add ability to not auto cast returns to their javascript type, and also add ability to force mysql connector to force date types to be strings.

The values after the || are default values.