### PR TITLE
add transaction methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ SSL: {
 }
 ```
 
-# Data Typing Options
+## Data Typing Options
 
 This connector gives you a few options for configuring how data is returned from the connector. 'typeCast' defaults to true, and converts
 data from the database to its javascript equivalent. For example, it will convert DATETIME SQL objects to a DATE javascript type.
 You can also set 'dateStrings' which defaults to false. If you set it to true it will override typeCast and force date returns to be a string instead of a DATE type.
 
-# Working within a transaction
+## Working within a transaction
 As of version 0.1.0 you can utilize sql transactions. Simply call the transactionConnection method to get a transaction connection and then begin the transaction.
 Then, write as many queries as you want, and when you are done, you can commit the transaction and all of your queries will be saved to the database or you can roll back the transaction and nothing done while inside that transaction will be saved. Some pseudo-code for how you might do that is below:
 ```

--- a/README.md
+++ b/README.md
@@ -31,3 +31,25 @@ SSL: {
 This connector gives you a few options for configuring how data is returned from the connector. 'typeCast' defaults to true, and converts
 data from the database to its javascript equivalent. For example, it will convert DATETIME SQL objects to a DATE javascript type.
 You can also set 'dateStrings' which defaults to false. If you set it to true it will override typeCast and force date returns to be a string instead of a DATE type.
+
+#Working within a transaction
+As of version 0.1.0 you can utilize sql transactions. Simply call the transactionConnection method to get a transaction connection and then begin the transaction.
+Then, write as many queries as you want, and when you are done, you can commit the transaction and all of your queries will be saved to the database or you can roll back the transaction and nothing done while inside that transaction will be saved. Some pseudo-code for how you might do that is below:
+```
+someMethod = async () => {
+    const pool = await dataSource.connect(DATABASE_POOL);
+    const transactionConnection = await dataSource.transactionConnection(pool);
+    transactionConnection.beginTransaction();
+
+    try {
+      await transactionConnection.execute(SOME_QUERY, []);
+      await transactionConnection.execute(SOME_QUERY, []);
+      await transactionConnection.execute(SOME_QUERY, []);
+
+      await transactionConnection.commitTransaction();
+    } catch (err) {
+      await transactionConnection.rollbackTransaction();
+      throw err;
+    }
+  };
+```

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Then, write as many queries as you want, and when you are done, you can commit t
 someMethod = async () => {
     const pool = await dataSource.connect(DATABASE_POOL);
     const transactionConnection = await dataSource.transactionConnection(pool);
-    transactionConnection.beginTransaction();
+    await transactionConnection.beginTransaction();
 
     try {
       await transactionConnection.execute(SOME_QUERY, []);

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ SSL: {
 }
 ```
 
-#Data Typing Options
+# Data Typing Options
 
 This connector gives you a few options for configuring how data is returned from the connector. 'typeCast' defaults to true, and converts
 data from the database to its javascript equivalent. For example, it will convert DATETIME SQL objects to a DATE javascript type.
 You can also set 'dateStrings' which defaults to false. If you set it to true it will override typeCast and force date returns to be a string instead of a DATE type.
 
-#Working within a transaction
+# Working within a transaction
 As of version 0.1.0 you can utilize sql transactions. Simply call the transactionConnection method to get a transaction connection and then begin the transaction.
 Then, write as many queries as you want, and when you are done, you can commit the transaction and all of your queries will be saved to the database or you can roll back the transaction and nothing done while inside that transaction will be saved. Some pseudo-code for how you might do that is below:
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@softrams/nodejs-mysql-connector",
-  "version": "0.0.13",
+  "version": "0.1.0",
   "description": "Database connector wrapper to work with MySQL database from nodejs applications",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
These 4 methods allow us to start a transaction, query while using the transaction connection, and both commit and rollback the transaction. We can then use this API something like this:

<img width="1211" alt="Screen Shot 2024-04-11 at 2 01 23 PM" src="https://github.com/softrams/nodejs-mysql-connector/assets/95388033/775faadc-8bc7-4dab-ba62-5a36eacbf55f">


I have tested that this works both committing and rolling back if there is an error